### PR TITLE
Introduce 'Copy Folder Structure As' submenu for format selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [0.2.3] - 2026-08-03
+
+### Added
+
+- **Copy Folder Structure As...** submenu in the Explorer context menu with **Plain Text** and **JSON** options for one-off format selection.
+
+### Changed
+
+- Removed the standalone **Copy Folder Structure** Explorer menu item; use **Copy Folder Structure As** to pick a format directly.
+
 ## [0.2.2] - 2026-04-27
 
 ### Added
@@ -73,5 +83,3 @@
     - Example Preview
     - Updated Preview Mode
 - v0.6 Added ignorePatterns in vscode settings
-
-## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@
 
 1. 📥 **Install** the extension from VS Code Marketplace
 2. 🖱️ **Right-click** any folder in Explorer
-3. 🎯 **Choose** "Copy Folder Structure" or "Create Folder Structure"
+3. 🎯 **Choose** "Copy Folder Structure As" or "Create Folder Structure"
 4. 🎉 **Done!** Your structure is ready to use
 
 <hr style="border: 2px solid black; width: 100%; " />
@@ -78,8 +78,8 @@
 ### 📁 Copy Folder Structure
 
 1. 🖱️ Right-click a folder in VS Code Explorer
-2. 📋 Select **"Copy Folder Structure"**
-3. 📄 Structure is copied to clipboard in your preferred format (JSON/Plain Text)
+2. 📋 Select **"Copy Folder Structure As"** and choose **Plain Text** or **JSON**
+3. 📄 Structure is copied to clipboard in the selected format
 
 ### 🏗️ Create Folder Structure
 
@@ -203,7 +203,7 @@ Directory structure:
 1. 🔍 **Scans** the selected folder intelligently
 2. 🙈 **Respects** .gitignore and exclude patterns
 3. 🚫 **Filters out** node_modules and hidden files automatically
-4. 📋 **Copies** structure in your chosen format (JSON or Plain Text)
+4. 📋 **Copies** structure in the format you pick from the submenu (JSON or Plain Text)
 
 ### 🏗️ Create Folder Structure
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Folder Structure Pro",
   "description": "Easily copy & create folder structures, file names and jump-ready line paths with a single click.",
   "publisher": "iamshreydxv",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "vscode": "^1.54.0"
   },
@@ -35,8 +35,13 @@
     ],
     "commands": [
       {
-        "command": "extension.copyFolderStructure",
-        "title": "Copy Folder Structure",
+        "command": "extension.copyFolderStructureAsPlainText",
+        "title": "Plain Text",
+        "category": "Explorer"
+      },
+      {
+        "command": "extension.copyFolderStructureAsJson",
+        "title": "JSON",
         "category": "Explorer"
       },
       {
@@ -55,10 +60,16 @@
         "category": "Editor"
       }
     ],
+    "submenus": [
+      {
+        "id": "extension.copyFolderStructureAs",
+        "label": "Copy Folder Structure As"
+      }
+    ],
     "menus": {
       "explorer/context": [
         {
-          "command": "extension.copyFolderStructure",
+          "submenu": "extension.copyFolderStructureAs",
           "when": "resource",
           "group": "5_folder-structure-pro"
         },
@@ -71,6 +82,16 @@
           "command": "extension.copyFileName",
           "when": "resourceExtname",
           "group": "5_folder-structure-pro"
+        }
+      ],
+      "extension.copyFolderStructureAs": [
+        {
+          "command": "extension.copyFolderStructureAsPlainText",
+          "group": "1_format"
+        },
+        {
+          "command": "extension.copyFolderStructureAsJson",
+          "group": "1_format"
         }
       ],
       "editor/context": [
@@ -92,7 +113,7 @@
             "Plain Text Format"
           ],
           "default": "Plain Text Format",
-          "description": "Format of the folder structure output (JSON or plain text)"
+          "description": "Default format for Create Folder Structure (JSON or plain text)"
         },
         "folderStructure.ignorePatterns": {
           "type": "array",

--- a/src/commands/copyStructure.ts
+++ b/src/commands/copyStructure.ts
@@ -1,10 +1,14 @@
 import * as vscode from 'vscode';
-import { ERROR_MESSAGES, DEFAULT_OUTPUT_FORMAT } from '../constants';
+import {
+    ERROR_MESSAGES,
+    JSON_OUTPUT_FORMAT,
+    PLAIN_TEXT_OUTPUT_FORMAT,
+} from '../constants';
 import { FileSystemService } from '../services/fileSystem';
 import { StructureService } from '../services/structure';
 import { OutputFormat } from '../types';
 
-export async function copyStructure(uri: vscode.Uri): Promise<void> {
+export async function copyStructure(uri: vscode.Uri, format: OutputFormat): Promise<void> {
     try {
         let target = uri;
         if (!target || !(await FileSystemService.isDirectory(target))) {
@@ -20,10 +24,7 @@ export async function copyStructure(uri: vscode.Uri): Promise<void> {
         }
 
         const structure = await StructureService.getStructure(target);
-        const outputFormat = vscode.workspace
-            .getConfiguration('folderStructure')
-            .get<OutputFormat>('outputFormat', DEFAULT_OUTPUT_FORMAT);
-        const formattedStructure = StructureService.formatStructure(structure, outputFormat);
+        const formattedStructure = StructureService.formatStructure(structure, format);
 
         await vscode.env.clipboard.writeText(formattedStructure);
         vscode.window.showInformationMessage('Folder structure copied to clipboard!');
@@ -32,6 +33,14 @@ export async function copyStructure(uri: vscode.Uri): Promise<void> {
             `Failed to copy folder structure: ${(error as Error).message}`,
         );
     }
+}
+
+export function copyStructureAsPlainText(uri: vscode.Uri): Promise<void> {
+    return copyStructure(uri, PLAIN_TEXT_OUTPUT_FORMAT);
+}
+
+export function copyStructureAsJson(uri: vscode.Uri): Promise<void> {
+    return copyStructure(uri, JSON_OUTPUT_FORMAT);
 }
 
 /*

--- a/src/commands/copyStructure.ts
+++ b/src/commands/copyStructure.ts
@@ -1,9 +1,5 @@
 import * as vscode from 'vscode';
-import {
-    ERROR_MESSAGES,
-    JSON_OUTPUT_FORMAT,
-    PLAIN_TEXT_OUTPUT_FORMAT,
-} from '../constants';
+import { ERROR_MESSAGES, JSON_OUTPUT_FORMAT, PLAIN_TEXT_OUTPUT_FORMAT } from '../constants';
 import { FileSystemService } from '../services/fileSystem';
 import { StructureService } from '../services/structure';
 import { OutputFormat } from '../types';

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,13 +1,17 @@
 import * as vscode from 'vscode';
 import { copyFileName } from './copyFileName';
-import { copyStructure } from './copyStructure';
-import { createStructure } from './createStructure';
 import { copyLinePath } from './copyLinePath';
+import { copyStructureAsJson, copyStructureAsPlainText } from './copyStructure';
+import { createStructure } from './createStructure';
 
 export function registerCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(
         vscode.commands.registerCommand('extension.copyFileName', copyFileName),
-        vscode.commands.registerCommand('extension.copyFolderStructure', copyStructure),
+        vscode.commands.registerCommand(
+            'extension.copyFolderStructureAsPlainText',
+            copyStructureAsPlainText,
+        ),
+        vscode.commands.registerCommand('extension.copyFolderStructureAsJson', copyStructureAsJson),
         vscode.commands.registerCommand('extension.createProjectFromStructure', createStructure),
         vscode.commands.registerCommand('extension.copyLinePath', copyLinePath),
     );

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,6 @@
-export const DEFAULT_OUTPUT_FORMAT = 'Plain Text Format';
+export const PLAIN_TEXT_OUTPUT_FORMAT = 'Plain Text Format';
+export const JSON_OUTPUT_FORMAT = 'JSON Format';
+export const DEFAULT_OUTPUT_FORMAT = PLAIN_TEXT_OUTPUT_FORMAT;
 export const DEFAULT_ENCODING = 'utf-8';
 
 // Tree drawing symbols used for the Plain Text-style formatter and parser

--- a/src/services/formatters/plainTextFormatter.ts
+++ b/src/services/formatters/plainTextFormatter.ts
@@ -39,9 +39,7 @@ export class PlainTextFormatter extends BaseFormatter {
                   : `${TREE_SYMBOLS.VERTICAL}${TREE_SYMBOLS.INDENT.slice(1)}`);
         const nested = this.formatStructure(value, childPrefix);
         const trailingNewline = isRoot && !isLastEntry ? '\n' : '';
-        return nested
-            ? `${line}\n${nested}${trailingNewline}`
-            : `${line}${trailingNewline}`;
+        return nested ? `${line}\n${nested}${trailingNewline}` : `${line}${trailingNewline}`;
     }
 
     private formatFileLeafEntry(

--- a/src/services/formatters/plainTextFormatter.ts
+++ b/src/services/formatters/plainTextFormatter.ts
@@ -39,7 +39,9 @@ export class PlainTextFormatter extends BaseFormatter {
                   : `${TREE_SYMBOLS.VERTICAL}${TREE_SYMBOLS.INDENT.slice(1)}`);
         const nested = this.formatStructure(value, childPrefix);
         const trailingNewline = isRoot && !isLastEntry ? '\n' : '';
-        return `${line}\n${nested}${trailingNewline}`;
+        return nested
+            ? `${line}\n${nested}${trailingNewline}`
+            : `${line}${trailingNewline}`;
     }
 
     private formatFileLeafEntry(

--- a/test/commands/copyStructure.test.ts
+++ b/test/commands/copyStructure.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { copyStructure } from '../../src/commands/copyStructure';
-import { StructureService } from '../../src/services/structure';
+import {
+    copyStructure,
+    copyStructureAsJson,
+    copyStructureAsPlainText,
+} from '../../src/commands/copyStructure';
+import { JSON_OUTPUT_FORMAT, PLAIN_TEXT_OUTPUT_FORMAT } from '../../src/constants';
 import { FileSystemService } from '../../src/services/fileSystem';
+import { StructureService } from '../../src/services/structure';
 import { resetVscodeMocks } from '../__mocks__/vscode';
 
 describe('copyStructure command', () => {
@@ -10,7 +15,7 @@ describe('copyStructure command', () => {
         resetVscodeMocks();
     });
 
-    it('copies formatted structure from a selected directory', async () => {
+    it('copies formatted structure in the requested format', async () => {
         const target = vscode.Uri.file('/workspace/app');
         vi.spyOn(FileSystemService, 'isDirectory').mockResolvedValue(true);
         vi.spyOn(StructureService, 'getStructure').mockResolvedValue({ app: { index: 'ts' } });
@@ -18,12 +23,45 @@ describe('copyStructure command', () => {
             'Directory structure:\n└── app/',
         );
 
-        await copyStructure(target);
+        await copyStructure(target, PLAIN_TEXT_OUTPUT_FORMAT);
 
+        expect(StructureService.formatStructure).toHaveBeenCalledWith(
+            { app: { index: 'ts' } },
+            PLAIN_TEXT_OUTPUT_FORMAT,
+        );
         expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith(
             'Directory structure:\n└── app/',
         );
         expect(vscode.window.showInformationMessage).toHaveBeenCalled();
+    });
+
+    it('uses plain text format via copyStructureAsPlainText', async () => {
+        const target = vscode.Uri.file('/workspace/app');
+        vi.spyOn(FileSystemService, 'isDirectory').mockResolvedValue(true);
+        vi.spyOn(StructureService, 'getStructure').mockResolvedValue({ app: {} });
+        vi.spyOn(StructureService, 'formatStructure').mockReturnValue('plain');
+
+        await copyStructureAsPlainText(target);
+
+        expect(StructureService.formatStructure).toHaveBeenCalledWith(
+            { app: {} },
+            PLAIN_TEXT_OUTPUT_FORMAT,
+        );
+    });
+
+    it('uses json format via copyStructureAsJson', async () => {
+        const target = vscode.Uri.file('/workspace/app');
+        vi.spyOn(FileSystemService, 'isDirectory').mockResolvedValue(true);
+        vi.spyOn(StructureService, 'getStructure').mockResolvedValue({ app: {} });
+        vi.spyOn(StructureService, 'formatStructure').mockReturnValue('{}');
+
+        await copyStructureAsJson(target);
+
+        expect(StructureService.formatStructure).toHaveBeenCalledWith(
+            { app: {} },
+            JSON_OUTPUT_FORMAT,
+        );
+        expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith('{}');
     });
 
     it('prompts for a folder when the provided uri is not a directory', async () => {
@@ -33,7 +71,7 @@ describe('copyStructure command', () => {
         vi.spyOn(StructureService, 'getStructure').mockResolvedValue({ picked: {} });
         vi.spyOn(StructureService, 'formatStructure').mockReturnValue('{}');
 
-        await copyStructure(undefined as unknown as vscode.Uri);
+        await copyStructure(undefined as unknown as vscode.Uri, PLAIN_TEXT_OUTPUT_FORMAT);
 
         expect(vscode.window.showOpenDialog).toHaveBeenCalled();
         expect(vscode.env.clipboard.writeText).toHaveBeenCalled();
@@ -43,7 +81,7 @@ describe('copyStructure command', () => {
         vi.spyOn(FileSystemService, 'isDirectory').mockResolvedValue(false);
         vscode.window.showOpenDialog.mockResolvedValueOnce(undefined);
 
-        await copyStructure(undefined as unknown as vscode.Uri);
+        await copyStructure(undefined as unknown as vscode.Uri, PLAIN_TEXT_OUTPUT_FORMAT);
 
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
             expect.stringContaining('Please select a valid folder'),
@@ -55,7 +93,7 @@ describe('copyStructure command', () => {
         vi.spyOn(FileSystemService, 'isDirectory').mockResolvedValue(true);
         vi.spyOn(StructureService, 'getStructure').mockRejectedValue(new Error('boom'));
 
-        await copyStructure(target);
+        await copyStructure(target, PLAIN_TEXT_OUTPUT_FORMAT);
 
         expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
             expect.stringContaining('boom'),

--- a/test/commands/index.test.ts
+++ b/test/commands/index.test.ts
@@ -12,9 +12,9 @@ describe('registerCommands', () => {
 
         registerCommands(context);
 
-        expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(4);
+        expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(5);
         expect(push).toHaveBeenCalledTimes(1);
-        expect(push.mock.calls[0]).toHaveLength(4);
+        expect(push.mock.calls[0]).toHaveLength(5);
     });
 });
 
@@ -26,7 +26,7 @@ describe('extension entrypoint', () => {
 
         activate(context);
 
-        expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(4);
+        expect(vscode.commands.registerCommand).toHaveBeenCalledTimes(5);
         expect(push).toHaveBeenCalledTimes(1);
     });
 

--- a/test/constants/index.test.ts
+++ b/test/constants/index.test.ts
@@ -3,12 +3,16 @@ import {
     DEFAULT_ENCODING,
     DEFAULT_OUTPUT_FORMAT,
     ERROR_MESSAGES,
+    JSON_OUTPUT_FORMAT,
+    PLAIN_TEXT_OUTPUT_FORMAT,
     TREE_SYMBOLS,
 } from '../../src/constants';
 
 describe('constants', () => {
     it('exports stable defaults and symbols', () => {
-        expect(DEFAULT_OUTPUT_FORMAT).toBe('Plain Text Format');
+        expect(PLAIN_TEXT_OUTPUT_FORMAT).toBe('Plain Text Format');
+        expect(JSON_OUTPUT_FORMAT).toBe('JSON Format');
+        expect(DEFAULT_OUTPUT_FORMAT).toBe(PLAIN_TEXT_OUTPUT_FORMAT);
         expect(DEFAULT_ENCODING).toBe('utf-8');
         expect(TREE_SYMBOLS.BRANCH).toBe('├── ');
         expect(ERROR_MESSAGES.TARGET_REQUIRED).toBe('Target directory is required.');

--- a/test/services/formatters.test.ts
+++ b/test/services/formatters.test.ts
@@ -45,4 +45,29 @@ describe('formatters', () => {
         expect(output).toContain('\n\n');
         expect(output).toContain('service-b/');
     });
+
+    it('does not add blank lines after empty directories', () => {
+        const structure: FolderStructure = {
+            docs: {
+                archive: {},
+                assets: {
+                    diagrams: {},
+                    icons: {},
+                    images: {},
+                },
+                'meeting-notes': {},
+                index: 'md',
+            },
+        };
+
+        const output = new PlainTextFormatter().format(structure);
+        expect(output).not.toMatch(/archive\/\n\s*\n/);
+        expect(output).not.toMatch(/diagrams\/\n\s*\n/);
+        expect(output).not.toMatch(/meeting-notes\/\n\s*\n/);
+        expect(output).toContain('├── archive/');
+        expect(output).toContain('├── assets/');
+        expect(output).toContain('│   ├── diagrams/');
+        expect(output).toContain('├── meeting-notes/');
+        expect(output).toContain('└── index.md');
+    });
 });


### PR DESCRIPTION
feat: introduce "Copy Folder Structure As" submenu for format selection https://github.com/ShreyPurohit/folder-structure-pro-vscode/issues/13#issue-4569344686

- Added a submenu in the Explorer context menu to choose between Plain Text and JSON formats for copying folder structures.
- Removed the standalone "Copy Folder Structure" menu item to streamline the user experience.
- Updated relevant documentation and tests to reflect these changes.